### PR TITLE
Provide examples, unify to a single command, unify entry points

### DIFF
--- a/text/text_navigation.py
+++ b/text/text_navigation.py
@@ -1,6 +1,7 @@
 import re
 from talon import ctrl, ui, Module, Context, actions, clip
 import itertools
+from typing import Union
 
 ctx = Context()
 mod = Module()
@@ -59,7 +60,7 @@ class Actions:
         occurrence_number: int,
     ):
         """navigate in the given direction to the occurrence_number-th time that the input text occurs, then execute the navigation_option at the given cursor_location"""
-        navigation(
+        actions.user.navigation_regex(
             navigation_option,
             direction,
             cursor_location,
@@ -67,11 +68,13 @@ class Actions:
             int(occurrence_number),
         )
 
+    # All other navigation commands dispatch to this one, so if you want to
+    # override its behavior, this is the one to override.
     def navigation_regex(
         navigation_option: str,
         direction: str,
         cursor_location: str,
-        regex: str,
+        regex: Union[str, re.Pattern],
         occurrence_number: int,
     ):
         """navigate in the given direction to the occurrence_number-th time that the input regex occurs, then execute the navigation_option at the given cursor_location"""
@@ -79,7 +82,7 @@ class Actions:
             navigation_option,
             direction,
             cursor_location,
-            re.compile(regex),
+            regex if isinstance(regex, re.Pattern) else re.compile(regex),
             int(occurrence_number),
         )
 
@@ -91,11 +94,11 @@ class Actions:
         occurrence_number: int,
     ):
         """navigate in the given direction to the occurrence_number-th time that the input search_option occurs, then execute the navigation_option at the given cursor_location"""
-        navigation(
+        actions.user.navigation_regex(
             navigation_option,
             direction,
             cursor_location,
-            re.compile(search_option_list[search_option]),
+            search_option_list[search_option],
             int(occurrence_number),
         )
 

--- a/text/text_navigation.talon
+++ b/text/text_navigation.talon
@@ -1,94 +1,66 @@
-# symbol navigation
-# examples:
-#   move left before comma 2
-#   select after comma: selects the first word after the first comma to the right of the cursor
-#   cut right dollar 3: cuts the third dollar to the right of the cursor
-# NOT USEFUL?: "cut right dollar" - is cutting single symbols all that useful?
-{user.navigation_option} ({user.arrow_key} [{user.cursor_location}] | {user.cursor_location}) <user.any_alphanumeric_key> [<number_small>]:
-	user.navigation(navigation_option, arrow_key or "RIGHT", cursor_location or "DEFAULT", any_alphanumeric_key, number_small or 1)
+## (2021-03-09) This syntax is experimental and may change. See below for an explanation.
+navigate [{user.arrow_key}] [{user.navigation_action}] [{user.before_or_after}] [<user.ordinals>] <user.navigation_target>:
+## If you use this command a lot, you may wish to have a shorter syntax that omits the navigate keyword:
+#{user.navigation_action} [{user.arrow_key}] [{user.before_or_after}] [<user.ordinals>] <user.navigation_target>:
+    user.navigation(navigation_action or "GO", arrow_key or "RIGHT", before_or_after or "DEFAULT", navigation_target, ordinals or 1)
 
-# text navigation
-# examples:
-#   move up after phrase hello world 2
-#   select before phrase test
-#   cut right phrase test
-{user.navigation_option} ({user.arrow_key} [{user.cursor_location}] | {user.cursor_location}) phrase <user.text> [<number_small>]:
-	user.navigation(navigation_option, arrow_key or "RIGHT", cursor_location or "DEFAULT", text, number_small or 1)
-
-# search_option navigation
-# examples:
-#   cut left after word 3
-#   select left word
-#   move after word
-# AMBIGUOUS: "(select right) (word too)" vs "select right word two"
-# DUPLICATE?: "select after word two" vs "select right word three"
-{user.navigation_option} ({user.arrow_key} [{user.cursor_location}] | {user.cursor_location}) {user.search_option} [<number_small>]:
-	user.navigation_regex(navigation_option, arrow_key or "RIGHT", cursor_location or "DEFAULT", search_option, number_small or 1)
+# ===== Examples of use =====
+#
+#   navigate comma: moves after the next "," on the line.
+#   navigate before five: moves before the next "5" on the line.
+#   navigate left underscore: moves before the previous "_" on the line.
+#   navigate left after second plex: moves after the second-previous "x" on the line.
+#
+# Besides characters, we can find phrases or move in predetermined units:
+#
+#   navigate phrase hello world: moves after the next "hello world" on the line.
+#   navigate left third word: moves left over three words.
+#   navigate before second big: moves before the second-next 'big' word (a chunk of anything except white space).
+#   navigate left second small: moves left over two 'small' words (chunks of a camelCase name).
+#
+# We can search several lines (default 10) above or below the cursor:
+#
+#   navigate up phrase john: moves before the previous "john" (case-insensitive) on the preceding lines.
+#   navigate down third period: moves after the third period on the following lines.
+#
+# Besides movement, we can cut, copy, select, clear (delete), or extend the current selection:
+#
+#   navigate cut after comma: cut the word following the next comma on the line.
+#   navigate left copy third word: copy the third word to the left.
+#   navigate extend third big: extend the selection three big words right.
+#   navigate down clear phrase I think: delete the next occurrence of "I think" on the following lines.
+#   navigate up select colon: select the closest colon on the preceeding lines.
+#
+# ===== Explanation of the grammar =====
+#
+# [{user.arrow_key}]: left, right, up, down (default: right)
+#   Which direction to navigate in.
+#   left/right work on the current line.
+#   up/down work on the closest lines (default: 10) above or below.
+#
+# [{user.navigation_action}]: move, extend, select, clear, cut, copy (default: move)
+#   What action to perform.
+#
+# [{user.before_or_after}]: before, after (default: special behavior)
+#   For move/extend: where to leave the cursor, before or after the target.
+#   Defaults to "after" for right/down and "before" for left/up.
+#
+#   For select/copy/cut: if absent, select/copy/cut the target iself. if
+#   present, the word before/after the target instead.
+#
+# [<user.ordinals>]: an english ordinal, like "second" (default: first)
+#   Which occurrence of the target to navigate to.
+#
+# <user.navigation_target>: one of the following:
+#   - a character name, like "comma" or "five".
+#   - "word" or "big" or "small"
+#   - "phrase <some text to search for>"
+#   Specifies the target to search for/navigate to.
 
 # The functionality for all these commands is covered in the lines above, but these commands are kept here for convenience. Originally from word_selection.talon.  
-word neck [<number_small>]: user.navigation_search_option("SELECT", "RIGHT", "DEFAULT", "word", number_small or 1)
-word pre [<number_small>]: user.navigation_search_option("SELECT", "LEFT", "DEFAULT", "word", number_small or 1)
-small word neck [<number_small>]: user.navigation_search_option("SELECT", "RIGHT", "DEFAULT", "small", number_small or 1)
-small word pre [<number_small>]: user.navigation_search_option("SELECT", "LEFT", "DEFAULT", "small", number_small or 1)
-big word neck [<number_small>]: user.navigation_search_option("SELECT", "RIGHT", "DEFAULT", "big", number_small or 1)
-big word pre [<number_small>]: user.navigation_search_option("SELECT", "LEFT", "DEFAULT", "big", number_small or 1)
-
-# # symbol navigation
-# move [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or 1)
-# move [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", 'BEFORE', any_alphanumeric_key, number_small or 1)
-# move [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", 'AFTER', any_alphanumeric_key, number_small or 1)
-# delete [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT","DEFAULT", any_alphanumeric_key, number_small or 1)
-# delete [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "BEFORE", any_alphanumeric_key, number_small or 1)
-# delete [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "AFTER", any_alphanumeric_key, number_small or 1)
-# extend [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or 1)
-# extend [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", 'BEFORE', any_alphanumeric_key, number_small or 1)
-# extend [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", 'AFTER', any_alphanumeric_key, number_small or 1)
-# cut [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or 1)
-# cut [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "BEFORE", any_alphanumeric_key, number_small or 1)
-# cut [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "AFTER", any_alphanumeric_key, number_small or 1)
-# copy [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or 1)
-# copy [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "BEFORE", any_alphanumeric_key, number_small or 1)
-# copy [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "AFTER", any_alphanumeric_key, number_small or 1)
-# select [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or 1)
-# select [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "BEFORE", any_alphanumeric_key, number_small or 1)
-# select [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "AFTER", any_alphanumeric_key, number_small or 1)
-
-# # search_option navigation
-# move [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("GO", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or 1)
-# move [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("GO", arrow_key or "RIGHT", "BEFORE", search_option, number_small or 1)
-# move [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("GO", arrow_key or "RIGHT", "AFTER", search_option, number_small or 1)
-# delete [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("DELETE", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or 1)
-# delete [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("DELETE", arrow_key or "RIGHT", "BEFORE", search_option, number_small or 1)
-# delete [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("DELETE", arrow_key or "RIGHT", "AFTER", search_option, number_small or 1)
-# extend [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("EXTEND", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or 1)
-# extend [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("EXTEND", arrow_key or "RIGHT", "BEFORE", search_option, number_small or 1)
-# extend [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("EXTEND", arrow_key or "RIGHT", "AFTER", search_option, number_small or 1)
-# cut [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("CUT", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or 1)
-# cut [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("CUT", arrow_key or "RIGHT", "BEFORE", search_option, number_small or 1)
-# cut [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("CUT", arrow_key or "RIGHT", "AFTER", search_option, number_small or 1)
-# copy [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("COPY", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or 1)
-# copy [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("COPY", arrow_key or "RIGHT", "BEFORE", search_option, number_small or 1)
-# copy [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("COPY", arrow_key or "RIGHT", "AFTER", search_option, number_small or 1)
-# select [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("SELECT", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or 1)
-# select [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("SELECT", arrow_key or "RIGHT", "BEFORE", search_option, number_small or 1)
-# select [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("SELECT", arrow_key or "RIGHT", "AFTER", search_option, number_small or 1)
-
-# # text navigation
-# move [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", "DEFAULT", text, number_small or 1)
-# move [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", "BEFORE", text, number_small or 1)
-# move [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", "AFTER", text, number_small or 1)
-# delete [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "DEFAULT", text, number_small or 1)
-# delete [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "BEFORE", text, number_small or 1)
-# delete [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "AFTER", text, number_small or 1)
-# extend [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", "DEFAULT", text, number_small or 1)
-# extend [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", "BEFORE", text, number_small or 1)
-# extend [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", "AFTER", text, number_small or 1)
-# cut [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "DEFAULT", text, number_small or 1)
-# cut [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "BEFORE", text, number_small or 1)
-# cut [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "AFTER", text, number_small or 1)
-# copy [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "DEFAULT", text, number_small or 1)
-# copy [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "BEFORE", text, number_small or 1)
-# copy [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "AFTER", text, number_small or 1)
-# select [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "DEFAULT", text, number_small or 1)
-# select [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "BEFORE", text, number_small or 1)
-# select [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "AFTER", text, number_small or 1)
+word neck [<number_small>]: user.navigation_by_name("SELECT", "RIGHT", "DEFAULT", "word", number_small or 1)
+word pre [<number_small>]: user.navigation_by_name("SELECT", "LEFT", "DEFAULT", "word", number_small or 1)
+small word neck [<number_small>]: user.navigation_by_name("SELECT", "RIGHT", "DEFAULT", "small", number_small or 1)
+small word pre [<number_small>]: user.navigation_by_name("SELECT", "LEFT", "DEFAULT", "small", number_small or 1)
+big word neck [<number_small>]: user.navigation_by_name("SELECT", "RIGHT", "DEFAULT", "big", number_small or 1)
+big word pre [<number_small>]: user.navigation_by_name("SELECT", "LEFT", "DEFAULT", "big", number_small or 1)

--- a/text/text_navigation.talon
+++ b/text/text_navigation.talon
@@ -1,86 +1,94 @@
 # symbol navigation
-move [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or  1)
-move [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", 'BEFORE', any_alphanumeric_key, number_small or  1)
-move [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", 'AFTER', any_alphanumeric_key, number_small or  1)
-delete [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT","DEFAULT", any_alphanumeric_key, number_small or  1)
-delete [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "BEFORE", any_alphanumeric_key, number_small or  1)
-delete [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "AFTER", any_alphanumeric_key, number_small or  1)
-extend [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or  1)
-extend [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", 'BEFORE', any_alphanumeric_key, number_small or  1)
-extend [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", 'AFTER', any_alphanumeric_key, number_small or  1)
-cut [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or  1)
-cut [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "BEFORE", any_alphanumeric_key, number_small or  1)
-cut [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "AFTER", any_alphanumeric_key, number_small or  1)
-copy [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or  1)
-copy [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "BEFORE", any_alphanumeric_key, number_small or  1)
-copy [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "AFTER", any_alphanumeric_key, number_small or  1)
-select [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or  1)
-select [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "BEFORE", any_alphanumeric_key, number_small or  1)
-select [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "AFTER", any_alphanumeric_key, number_small or  1)
+# examples:
+#   move left before comma 2
+#   select after comma: selects the first word after the first comma to the right of the cursor
+#   cut right dollar 3: cuts the third dollar to the right of the cursor
+# NOT USEFUL?: "cut right dollar" - is cutting single symbols all that useful?
+{user.navigation_option} ({user.arrow_key} [{user.cursor_location}] | {user.cursor_location}) <user.any_alphanumeric_key> [<number_small>]:
+	user.navigation(navigation_option, arrow_key or "RIGHT", cursor_location or "DEFAULT", any_alphanumeric_key, number_small or 1)
+
+# text navigation
+# examples:
+#   move up after phrase hello world 2
+#   select before phrase test
+#   cut right phrase test
+{user.navigation_option} ({user.arrow_key} [{user.cursor_location}] | {user.cursor_location}) phrase <user.text> [<number_small>]:
+	user.navigation(navigation_option, arrow_key or "RIGHT", cursor_location or "DEFAULT", text, number_small or 1)
 
 # search_option navigation
-move [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("GO", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or  1)
-move [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("GO", arrow_key or "RIGHT", "BEFORE", search_option, number_small or  1)
-move [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("GO", arrow_key or "RIGHT", "AFTER", search_option, number_small or  1)
-delete [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("DELETE", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or  1)
-delete [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("DELETE", arrow_key or "RIGHT", "BEFORE", search_option, number_small or  1)
-delete [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("DELETE", arrow_key or "RIGHT", "AFTER", search_option, number_small or  1)
-extend [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("EXTEND", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or  1)
-extend [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("EXTEND", arrow_key or "RIGHT", "BEFORE", search_option, number_small or  1)
-extend [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("EXTEND", arrow_key or "RIGHT", "AFTER", search_option, number_small or  1)
-cut [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("CUT", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or  1)
-cut [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("CUT", arrow_key or "RIGHT", "BEFORE", search_option, number_small or  1)
-cut [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("CUT", arrow_key or "RIGHT", "AFTER", search_option, number_small or  1)
-copy [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("COPY", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or  1)
-copy [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("COPY", arrow_key or "RIGHT", "BEFORE", search_option, number_small or  1)
-copy [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("COPY", arrow_key or "RIGHT", "AFTER", search_option, number_small or  1)
-select [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("SELECT", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or  1)
-select [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("SELECT", arrow_key or "RIGHT", "BEFORE", search_option, number_small or  1)
-select [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("SELECT", arrow_key or "RIGHT", "AFTER", search_option, number_small or  1)
-
-# text navigation
-move [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", "DEFAULT", text, number_small or  1)
-move [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", "BEFORE", text, number_small or  1)
-move [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", "AFTER", text, number_small or  1)
-delete [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "DEFAULT", text, number_small or  1)
-delete [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "BEFORE", text, number_small or  1)
-delete [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "AFTER", text, number_small or  1)
-extend [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", "DEFAULT", text, number_small or  1)
-extend [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", "BEFORE", text, number_small or  1)
-extend [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", "AFTER", text, number_small or  1)
-cut [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "DEFAULT", text, number_small or  1)
-cut [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "BEFORE", text, number_small or  1)
-cut [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "AFTER", text, number_small or  1)
-copy [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "DEFAULT", text, number_small or  1)
-copy [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "BEFORE", text, number_small or  1)
-copy [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "AFTER", text, number_small or  1)
-select [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "DEFAULT", text, number_small or  1)
-select [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "BEFORE", text, number_small or  1)
-select [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "AFTER", text, number_small or  1)
+# examples:
+#   cut left after word 3
+#   select left word
+#   move after word
+# AMBIGUOUS: "(select right) (word too)" vs "select right word two"
+# DUPLICATE?: "select after word two" vs "select right word three"
+{user.navigation_option} ({user.arrow_key} [{user.cursor_location}] | {user.cursor_location}) {user.search_option} [<number_small>]:
+	user.navigation_regex(navigation_option, arrow_key or "RIGHT", cursor_location or "DEFAULT", search_option, number_small or 1)
 
 # The functionality for all these commands is covered in the lines above, but these commands are kept here for convenience. Originally from word_selection.talon.  
-word neck [<number_small>]: user.navigation_search_option("SELECT", "RIGHT", "DEFAULT", "word", number_small or  1)
-word pre [<number_small>]: user.navigation_search_option("SELECT", "LEFT", "DEFAULT", "word", number_small or  1)
-small word neck [<number_small>]: user.navigation_search_option("SELECT", "RIGHT", "DEFAULT", "small", number_small or  1)
-small word pre [<number_small>]: user.navigation_search_option("SELECT", "LEFT", "DEFAULT", "small", number_small or  1)
-big word neck [<number_small>]: user.navigation_search_option("SELECT", "RIGHT", "DEFAULT", "big", number_small or  1)
-big word pre [<number_small>]: user.navigation_search_option("SELECT", "LEFT", "DEFAULT", "big", number_small or  1)
- 
-# if you prefer succinct commands, comment or remove everything above and use the below
-# text navigation
-# [{user.navigation_option}] [{user.arrow_key}] {user.cursor_location} <user.text> [<number>]:
-# 	user.navigation(navigation_option or "GO", arrow_key or "RIGHT", cursor_location, text, number or  1)
-# {user.navigation_option} [{user.arrow_key}] [{user.cursor_location}] <user.text> [<number>]:
-# 	user.navigation(navigation_option, arrow_key or "RIGHT", cursor_location or "DEFAULT", text, number or  1)
-	
+word neck [<number_small>]: user.navigation_search_option("SELECT", "RIGHT", "DEFAULT", "word", number_small or 1)
+word pre [<number_small>]: user.navigation_search_option("SELECT", "LEFT", "DEFAULT", "word", number_small or 1)
+small word neck [<number_small>]: user.navigation_search_option("SELECT", "RIGHT", "DEFAULT", "small", number_small or 1)
+small word pre [<number_small>]: user.navigation_search_option("SELECT", "LEFT", "DEFAULT", "small", number_small or 1)
+big word neck [<number_small>]: user.navigation_search_option("SELECT", "RIGHT", "DEFAULT", "big", number_small or 1)
+big word pre [<number_small>]: user.navigation_search_option("SELECT", "LEFT", "DEFAULT", "big", number_small or 1)
+
 # # symbol navigation
-# [{user.navigation_option}] [{user.arrow_key}] {user.cursor_location} <user.any_alphanumeric_key> [<number>]:
-# 	user.navigation(navigation_option or "GO", arrow_key or "RIGHT", cursor_location, any_alphanumeric_key, number or  1)
-# {user.navigation_option} [{user.arrow_key}] [{user.cursor_location}] <user.any_alphanumeric_key> [<number>]:
-# 	user.navigation(navigation_option, arrow_key or "RIGHT", cursor_location or "DEFAULT", any_alphanumeric_key, number or  1)
+# move [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or 1)
+# move [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", 'BEFORE', any_alphanumeric_key, number_small or 1)
+# move [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", 'AFTER', any_alphanumeric_key, number_small or 1)
+# delete [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT","DEFAULT", any_alphanumeric_key, number_small or 1)
+# delete [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "BEFORE", any_alphanumeric_key, number_small or 1)
+# delete [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "AFTER", any_alphanumeric_key, number_small or 1)
+# extend [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or 1)
+# extend [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", 'BEFORE', any_alphanumeric_key, number_small or 1)
+# extend [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", 'AFTER', any_alphanumeric_key, number_small or 1)
+# cut [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or 1)
+# cut [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "BEFORE", any_alphanumeric_key, number_small or 1)
+# cut [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "AFTER", any_alphanumeric_key, number_small or 1)
+# copy [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or 1)
+# copy [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "BEFORE", any_alphanumeric_key, number_small or 1)
+# copy [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "AFTER", any_alphanumeric_key, number_small or 1)
+# select [{user.arrow_key}] symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "DEFAULT", any_alphanumeric_key, number_small or 1)
+# select [{user.arrow_key}] before symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "BEFORE", any_alphanumeric_key, number_small or 1)
+# select [{user.arrow_key}] after symbol <user.any_alphanumeric_key> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "AFTER", any_alphanumeric_key, number_small or 1)
 
 # # search_option navigation
-# move [{user.arrow_key}] {user.cursor_location} {user.search_option} [<number>]:
-# 	user.navigation_regex("GO", arrow_key or "RIGHT", cursor_location, search_option, number or  1)
-# {user.navigation_option} [{user.arrow_key}] [{user.cursor_location}] {user.search_option} [<number>]:
-# 	user.navigation_regex(navigation_option, arrow_key or "RIGHT", cursor_location or "DEFAULT", search_option, number or  1)
+# move [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("GO", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or 1)
+# move [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("GO", arrow_key or "RIGHT", "BEFORE", search_option, number_small or 1)
+# move [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("GO", arrow_key or "RIGHT", "AFTER", search_option, number_small or 1)
+# delete [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("DELETE", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or 1)
+# delete [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("DELETE", arrow_key or "RIGHT", "BEFORE", search_option, number_small or 1)
+# delete [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("DELETE", arrow_key or "RIGHT", "AFTER", search_option, number_small or 1)
+# extend [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("EXTEND", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or 1)
+# extend [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("EXTEND", arrow_key or "RIGHT", "BEFORE", search_option, number_small or 1)
+# extend [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("EXTEND", arrow_key or "RIGHT", "AFTER", search_option, number_small or 1)
+# cut [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("CUT", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or 1)
+# cut [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("CUT", arrow_key or "RIGHT", "BEFORE", search_option, number_small or 1)
+# cut [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("CUT", arrow_key or "RIGHT", "AFTER", search_option, number_small or 1)
+# copy [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("COPY", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or 1)
+# copy [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("COPY", arrow_key or "RIGHT", "BEFORE", search_option, number_small or 1)
+# copy [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("COPY", arrow_key or "RIGHT", "AFTER", search_option, number_small or 1)
+# select [{user.arrow_key}] seek {user.search_option} [<number_small>]: user.navigation_regex("SELECT", arrow_key or "RIGHT", "DEFAULT", search_option, number_small or 1)
+# select [{user.arrow_key}] before seek {user.search_option} [<number_small>]: user.navigation_regex("SELECT", arrow_key or "RIGHT", "BEFORE", search_option, number_small or 1)
+# select [{user.arrow_key}] after seek {user.search_option} [<number_small>]: user.navigation_regex("SELECT", arrow_key or "RIGHT", "AFTER", search_option, number_small or 1)
+
+# # text navigation
+# move [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", "DEFAULT", text, number_small or 1)
+# move [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", "BEFORE", text, number_small or 1)
+# move [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("GO", arrow_key or "RIGHT", "AFTER", text, number_small or 1)
+# delete [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "DEFAULT", text, number_small or 1)
+# delete [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "BEFORE", text, number_small or 1)
+# delete [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("DELETE", arrow_key or "RIGHT", "AFTER", text, number_small or 1)
+# extend [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", "DEFAULT", text, number_small or 1)
+# extend [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", "BEFORE", text, number_small or 1)
+# extend [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("EXTEND", arrow_key or "RIGHT", "AFTER", text, number_small or 1)
+# cut [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "DEFAULT", text, number_small or 1)
+# cut [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "BEFORE", text, number_small or 1)
+# cut [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("CUT", arrow_key or "RIGHT", "AFTER", text, number_small or 1)
+# copy [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "DEFAULT", text, number_small or 1)
+# copy [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "BEFORE", text, number_small or 1)
+# copy [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("COPY", arrow_key or "RIGHT", "AFTER", text, number_small or 1)
+# select [{user.arrow_key}] phrase <user.text> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "DEFAULT", text, number_small or 1)
+# select [{user.arrow_key}] before phrase <user.text> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "BEFORE", text, number_small or 1)
+# select [{user.arrow_key}] after phrase <user.text> [<number_small>]: user.navigation("SELECT", arrow_key or "RIGHT", "AFTER", text, number_small or 1)


### PR DESCRIPTION
Feel free to take from this pull request only what you need, some of the refactorings/renamings may not be to your taste.

I'm also not entirely sure I haven't introduced some bugs, although I don't see how. In particular the following commands do not do the expected thing for me:

1. “navigate select after comma” does nothing for me, when I would expect it to select the word after the next comma.
2. “navigate up/down select comma” seem to have an off-by-one error. Instead of selecting the comma they select the character before or after it.